### PR TITLE
Generate dockerfile and requirements txt for public components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+# Install system packages (build tools and MySQL client libs)
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        default-libmysqlclient-dev \
+        pkg-config \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+RUN useradd -m appuser
+WORKDIR /app
+
+# Copy dependency file first to leverage Docker layer caching
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY src ./src
+COPY docs ./docs
+COPY MySQL ./MySQL
+COPY src/templates ./src/templates
+COPY src/static ./src/static
+
+# Environment variables
+ENV FLASK_APP=src/App.py \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Expose port
+EXPOSE 8000
+
+# Healthcheck (basic)
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -f http://localhost:8000/ || exit 1
+
+# Run with Gunicorn
+# Binding to 0.0.0.0 makes the server accessible from outside the container
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--chdir", "/app", "src.App:app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# Core web framework
+Flask>=2.3
+
+# ORM and MySQL driver used by the app
+Flask-SQLAlchemy>=3.1
+SQLAlchemy>=2.0
+PyMySQL>=1.1
+
+# HTTP client used by RemoteAccess
+requests>=2.31
+
+# Production WSGI server
+gunicorn>=21.2
+
+# Testing (optional)
+pytest>=8.0
+
+# Raspberry Pi camera and hardware stack (only on Raspberry Pi OS; DO NOT install on regular Linux/Windows/macOS)
+# picamera2  # Provided by Raspberry Pi OS repositories; not installable via PyPI in generic environments
+# rpi-lgpio
+# libcamera


### PR DESCRIPTION
Add Dockerfile and requirements.txt to containerize the Flask application for production deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-722d7336-325e-4d3d-9c4f-dbd14d632389">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-722d7336-325e-4d3d-9c4f-dbd14d632389">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

